### PR TITLE
🐛 Member sms configuration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,9 +13,9 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: '8.0.3'
-                    tools: pecl, composer, flex, cs2pr, php-cs-fixer
+                    tools: pecl, composer, flex, cs2pr, php-cs-fixer, phpmd, phpcpd, phpstan
                     ini-values: memory_limit=-1
-                    extensions: intl, xsl, mysql, gd, zip, amqp, ctype, json, soap
+                    extensions: xsl, zip, ctype, json
             -   name: Cache Composer packages
                 uses: actions/cache@v1
                 with:
@@ -30,13 +30,13 @@ jobs:
             -   name: Run PHPUnit units tests
                 run: vendor/bin/phpunit --testdox
             -   name: Run PHPMD
-                run: vendor/bin/phpmd src text .phpmd.xml
+                run: phpmd src text .phpmd.xml
             -   name: Run PHPCPD
-                run: vendor/bin/phpcpd src
+                run: phpcpd src
             -   name: Run PHP-CS-Fixer fix
                 run: php-cs-fixer fix --dry-run --diff --using-cache=no --ansi --format=checkstyle | cs2pr
             -   name: Run PHPStan analysis
-                run: vendor/bin/phpstan analyse --memory-limit=4G -l 4 --error-format=checkstyle | cs2pr
+                run: phpstan analyse --memory-limit=4G -l 8 src --error-format=checkstyle | cs2pr
             -   name: Upload artifacts
                 if: always()
                 uses: actions/upload-artifact@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 yarn.lock
 tests/Integration
 .php-version
+tools/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -6,7 +6,7 @@ This file is part of the Easyblue YouSign project.
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 OEF;
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
@@ -25,24 +25,28 @@ return PhpCsFixer\Config::create()
         'phpdoc_order' => true,
         'phpdoc_separation' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag' => true,
+        'general_phpdoc_tag_rename' => true,
+        'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_tag_type' => true,
         'no_empty_phpdoc' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'single_quote' => true,
         'yoda_style' => true,
         'no_extra_blank_lines' => [
-            'break',
-            'continue',
-            'extra',
-            'return',
-            'throw',
-            'use',
-            'parenthesis_brace_block',
-            'square_brace_block',
-            'curly_brace_block',
+            'tokens' => [
+                'break',
+                'continue',
+                'extra',
+                'return',
+                'throw',
+                'use',
+                'parenthesis_brace_block',
+                'square_brace_block',
+                'curly_brace_block',
+            ],
         ],
-        'no_short_echo_tag' => true,
+        'echo_tag_syntax' => true,
         'no_unreachable_default_argument_value' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,7 @@
     },
     "require-dev": {
         "brainmaestro/composer-git-hooks": "^2.8",
-        "friendsofphp/php-cs-fixer": "^2.18",
-        "phpmd/phpmd": "^2.9",
-        "phpstan/phpstan": "^0.12.31",
-        "phpunit/phpunit": "^9.1",
-        "sebastian/phpcpd": "^6.0"
+        "phpunit/phpunit": "^9.5"
     },
     "extra": {
         "hooks": {

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -12,6 +12,7 @@ declare(strict_types = 1);
 namespace Easyblue\YouSign\Factory;
 
 use Easyblue\YouSign\Http\Client;
+use Easyblue\YouSign\Resources\AbstractResource;
 use Easyblue\YouSign\Serializer\YouSignSerializer;
 
 /**
@@ -33,7 +34,8 @@ final class Factory
         $this->serializer = new YouSignSerializer();
     }
 
-    public function __call(string $name, $args)
+    /** @param array|null $args */
+    public function __call(string $name, $args): AbstractResource
     {
         $resource = $this->getResourcesClass($name);
 

--- a/src/Helper/Base64Helper.php
+++ b/src/Helper/Base64Helper.php
@@ -13,17 +13,18 @@ namespace Easyblue\YouSign\Helper;
 
 class Base64Helper
 {
-    public static function isBase64Encoded($data)
+    public static function isBase64Encoded(string $data): bool
     {
-        return preg_match('%^[a-zA-Z0-9/+]*={0,2}$%', $data) > 0;
+        return ((int) preg_match('%^[a-zA-Z0-9/+]*={0,2}$%', $data)) > 0;
     }
 
-    public static function base64Encode($data)
+    public static function base64Encode(string $data): string
     {
         return base64_encode($data);
     }
 
-    public static function base64decode($data)
+    /** @return string|false */
+    public static function base64decode(string $data)
     {
         return base64_decode($data, true);
     }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -14,14 +14,15 @@ namespace Easyblue\YouSign\Http;
 use Easyblue\YouSign\Exception\YouSignClientException;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
+use Psr\Http\Message\MessageInterface;
 
 class Client
 {
-    const ENV_PROD    = 'prod';
-    const ENV_STAGING = 'staging';
+    public const ENV_PROD    = 'prod';
+    public const ENV_STAGING = 'staging';
 
-    const URL_PROD    = 'https://api.yousign.com';
-    const URL_STAGING = 'https://staging-api.yousign.com';
+    public const URL_PROD    = 'https://api.yousign.com';
+    public const URL_STAGING = 'https://staging-api.yousign.com';
 
     public string $key;
     public string $baseUrl;
@@ -48,7 +49,7 @@ class Client
      * @throws YouSignClientException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function request(string $method, string $endpoint, array $options = [])
+    public function request(string $method, string $endpoint, array $options = []): MessageInterface
     {
         $headers = ['Authorization' => 'Bearer '.$this->key];
 

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -78,6 +78,8 @@ class File
 
     /**
      * @Groups({"read", "write"})
+     *
+     * @var int|string|bool
      */
     protected $position;
 
@@ -213,12 +215,14 @@ class File
         return $this;
     }
 
+    /** @return int|string|bool */
     public function getPosition()
     {
         return $this->position;
     }
 
-    public function setPosition($position)
+    /** @param int|string|bool $position */
+    public function setPosition($position): self
     {
         $this->position = $position;
 

--- a/src/Model/FileObject.php
+++ b/src/Model/FileObject.php
@@ -268,7 +268,7 @@ class FileObject
 
     public function getFileId(): ?string
     {
-        if ($this->getFile()) {
+        if (null !== $this->getFile()) {
             return $this->getFile()->getId();
         }
 

--- a/src/Model/Member.php
+++ b/src/Model/Member.php
@@ -90,7 +90,7 @@ class Member
     /**
      * @Groups({"read", "write"})
      */
-    protected ?ModeSmsConfiguration $modeSmsConfiguration = null;
+    protected ?OperationModeSmsConfiguration $operationModeSmsConfiguration = null;
 
     public function getId(): ?string
     {
@@ -267,14 +267,14 @@ class Member
         return $this;
     }
 
-    public function getModeSmsConfiguration(): ?ModeSmsConfiguration
+    public function getOperationModeSmsConfiguration(): ?OperationModeSmsConfiguration
     {
-        return $this->modeSmsConfiguration;
+        return $this->operationModeSmsConfiguration;
     }
 
-    public function setModeSmsConfiguration(?ModeSmsConfiguration $modeSmsConfiguration): self
+    public function setOperationModeSmsConfiguration(?OperationModeSmsConfiguration $operationModeSmsConfiguration): self
     {
-        $this->modeSmsConfiguration = $modeSmsConfiguration;
+        $this->operationModeSmsConfiguration = $operationModeSmsConfiguration;
 
         return $this;
     }

--- a/src/Model/Metadata.php
+++ b/src/Model/Metadata.php
@@ -14,5 +14,6 @@ namespace Easyblue\YouSign\Model;
 class Metadata
 {
     protected string $key;
+    /** @var int|string|bool|array */
     protected $value;
 }

--- a/src/Model/OperationModeSmsConfiguration.php
+++ b/src/Model/OperationModeSmsConfiguration.php
@@ -13,7 +13,7 @@ namespace Easyblue\YouSign\Model;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 
-class ModeSmsConfiguration
+class OperationModeSmsConfiguration
 {
     /**
      * @Groups({"read", "write"})

--- a/src/Model/Procedure.php
+++ b/src/Model/Procedure.php
@@ -17,11 +17,11 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 class Procedure
 {
     use TimestampsTrait;
-    const STATE_DRAFT    = 'draft';
-    const STATE_ACTIVE   = 'active';
-    const STATE_FINISHED = 'finished';
-    const STATE_EXPIRED  = 'expired';
-    const STATE_REFUSED  = 'refused';
+    public const STATE_DRAFT    = 'draft';
+    public const STATE_ACTIVE   = 'active';
+    public const STATE_FINISHED = 'finished';
+    public const STATE_EXPIRED  = 'expired';
+    public const STATE_REFUSED  = 'refused';
 
     /**
      * @Groups({"read"})

--- a/src/Model/ProcedureConfigEmail.php
+++ b/src/Model/ProcedureConfigEmail.php
@@ -16,14 +16,14 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 
 class ProcedureConfigEmail
 {
-    const PROCEDURE_STARTED  = 'procedure.started';
-    const PROCEDURE_FINISHED = 'procedure.finished';
-    const PROCEDURE_REFUSED  = 'procedure.refused';
-    const PROCEDURE_EXPIRED  = 'procedure.expired';
-    const PROCEDURE_DELETED  = 'procedure.deleted';
-    const MEMBER_STARTED     = 'member.started';
-    const MEMBER_FINISHED    = 'member.finished';
-    const COMMENT_CREATED    = 'comment.created';
+    public const PROCEDURE_STARTED  = 'procedure.started';
+    public const PROCEDURE_FINISHED = 'procedure.finished';
+    public const PROCEDURE_REFUSED  = 'procedure.refused';
+    public const PROCEDURE_EXPIRED  = 'procedure.expired';
+    public const PROCEDURE_DELETED  = 'procedure.deleted';
+    public const MEMBER_STARTED     = 'member.started';
+    public const MEMBER_FINISHED    = 'member.finished';
+    public const COMMENT_CREATED    = 'comment.created';
 
     /**
      * @Groups({"read", "write"})

--- a/src/Model/ProcedureConfigWebhook.php
+++ b/src/Model/ProcedureConfigWebhook.php
@@ -16,14 +16,14 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 
 class ProcedureConfigWebhook
 {
-    const PROCEDURE_STARTED  = 'procedure.started';
-    const PROCEDURE_FINISHED = 'procedure.finished';
-    const PROCEDURE_REFUSED  = 'procedure.refused';
-    const PROCEDURE_EXPIRED  = 'procedure.expired';
-    const PROCEDURE_DELETED  = 'procedure.deleted';
-    const MEMBER_STARTED     = 'member.started';
-    const MEMBER_FINISHED    = 'member.finished';
-    const COMMENT_CREATED    = 'comment.created';
+    public const PROCEDURE_STARTED  = 'procedure.started';
+    public const PROCEDURE_FINISHED = 'procedure.finished';
+    public const PROCEDURE_REFUSED  = 'procedure.refused';
+    public const PROCEDURE_EXPIRED  = 'procedure.expired';
+    public const PROCEDURE_DELETED  = 'procedure.deleted';
+    public const MEMBER_STARTED     = 'member.started';
+    public const MEMBER_FINISHED    = 'member.finished';
+    public const COMMENT_CREATED    = 'comment.created';
 
     /**
      * @Groups({"read", "write"})

--- a/src/Model/TimestampsTrait.php
+++ b/src/Model/TimestampsTrait.php
@@ -30,7 +30,7 @@ trait TimestampsTrait
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTime $createdAt): self
     {
         $this->createdAt = $createdAt;
 
@@ -42,7 +42,7 @@ trait TimestampsTrait
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt)
+    public function setUpdatedAt(?\DateTime $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Resources/FileResource.php
+++ b/src/Resources/FileResource.php
@@ -15,7 +15,7 @@ use Easyblue\YouSign\Model\File;
 
 class FileResource extends AbstractResource
 {
-    const ENDPOINT = '/files';
+    public const ENDPOINT = '/files';
 
     /**
      * @return File[]
@@ -51,7 +51,7 @@ class FileResource extends AbstractResource
         return $this->serializer->deserialize($json, File::class);
     }
 
-    public function download(string $id, $asBinary = true): string
+    public function download(string $id, bool $asBinary = true): string
     {
         $id       = str_replace('/files/', '', $id);
         $endPoint =  sprintf('/files/%s/download', $id);

--- a/src/Resources/ProcedureResource.php
+++ b/src/Resources/ProcedureResource.php
@@ -15,8 +15,9 @@ use Easyblue\YouSign\Model\Procedure;
 
 class ProcedureResource extends AbstractResource
 {
-    const ENDPOINT = '/procedures';
+    public const ENDPOINT = '/procedures';
 
+    /** @return mixed */
     public function all()
     {
         $response =  $this->client->request('GET', self::ENDPOINT);
@@ -40,6 +41,7 @@ class ProcedureResource extends AbstractResource
         return $this->serializer->deserialize($json, Procedure::class);
     }
 
+    /** @return mixed */
     public function get(string $id)
     {
         $response =  $this->client->request('GET', $id);

--- a/src/Serializer/Normalizer/HeaderNormalizer.php
+++ b/src/Serializer/Normalizer/HeaderNormalizer.php
@@ -18,17 +18,20 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 class HeaderNormalizer implements DenormalizerInterface
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @throws NotNormalizableValueException
      */
     public function denormalize($data, string $type, string $format = null, array $context = [])
     {
-        return new Header(json_decode(json_encode($data), true));
+        /** @var string $encodedJSON */
+        $encodedJSON = json_encode($data);
+
+        return new Header(json_decode($encodedJSON, true));
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function supportsDenormalization($data, string $type, string $format = null)
     {

--- a/src/Serializer/YouSignSerializer.php
+++ b/src/Serializer/YouSignSerializer.php
@@ -42,18 +42,24 @@ class YouSignSerializer
         $this->serializer = new Serializer($normalizers, [new JsonEncode(), new JsonDecode()]);
     }
 
+    /** @return mixed */
     public function deserialize(string $data, string $entityClass)
     {
         return $this->serializer->deserialize($data, $entityClass, 'json', ['groups' => ['read']]);
     }
 
+    /** @param mixed $object */
     public function serialize($object): string
     {
         return $this->serializer->serialize($object, 'json', ['groups' => ['write']]);
     }
 
+    /** @param mixed $data */
     public function normalize($data): array
     {
-        return $this->serializer->normalize($data, null, ['groups' => ['write'], AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
+        /** @var array */
+        $normalize = $this->serializer->normalize($data, null, ['groups' => ['write'], AbstractObjectNormalizer::SKIP_NULL_VALUES => true]);
+
+        return $normalize;
     }
 }

--- a/tests/Factory/FactoryTest.php
+++ b/tests/Factory/FactoryTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
 {
-    private $factory;
+    private Factory $factory;
 
     protected function setUp(): void
     {

--- a/tests/Fixtures/procedure.json
+++ b/tests/Fixtures/procedure.json
@@ -251,7 +251,7 @@
       "operationCustomModes": [
         "sms"
       ],
-      "modeSmsConfiguration": {
+      "operationModeSmsConfiguration": {
         "content": "Hello, your code for signature is {{code}}."
       }
     }

--- a/tests/Fixtures/procedures.json
+++ b/tests/Fixtures/procedures.json
@@ -252,7 +252,7 @@
         "operationCustomModes": [
           "sms"
         ],
-        "modeSmsConfiguration": {
+        "operationModeSmsConfiguration": {
           "content": "Hello, your code for signature is {{code}}."
         }
       }

--- a/tests/Model/FileTest.php
+++ b/tests/Model/FileTest.php
@@ -19,6 +19,7 @@ class FileTest extends TestCase
 {
     public function testSerialize(): void
     {
+        /** @var string */
         $json = file_get_contents(__DIR__.'/../Fixtures/file.json');
 
         $serializer = new YouSignSerializer();
@@ -29,8 +30,8 @@ class FileTest extends TestCase
         $this->assertSame('signable', $file->getType());
         $this->assertSame('application/pdf', $file->getContentType());
         $this->assertSame('string', $file->getDescription());
-        $this->assertSame('2020-04-23T18:25:43+00:00', $file->getCreatedAt()->format('c'));
-        $this->assertSame('2020-04-23T18:25:43+00:00', $file->getUpdatedAt()->format('c'));
+        $this->assertSame('2020-04-23T18:25:43+00:00', null !== $file->getCreatedAt() ? $file->getCreatedAt()->format('c') : null);
+        $this->assertSame('2020-04-23T18:25:43+00:00', null !== $file->getUpdatedAt() ? $file->getUpdatedAt()->format('c') : null);
         $this->assertNull($file->getMetadata());
         $this->assertSame('/workspaces/9d1ede2b-5687-4440-bdc8-dd0bc64f668c', $file->getWorkspace());
         $this->assertSame('/users/9d1ede2b-5687-4440-bdc8-dd0bc64f668c', $file->getCreator());

--- a/tests/Model/ProcedureTest.php
+++ b/tests/Model/ProcedureTest.php
@@ -13,6 +13,7 @@ namespace Easyblue\YouSign\tests\Model;
 
 use Easyblue\YouSign\Model\Email;
 use Easyblue\YouSign\Model\Procedure;
+use Easyblue\YouSign\Model\ProcedureConfig;
 use Easyblue\YouSign\Model\ProcedureConfigEmail;
 use Easyblue\YouSign\Model\ProcedureConfigWebhook;
 use Easyblue\YouSign\Model\Webhook;
@@ -23,6 +24,7 @@ class ProcedureTest extends TestCase
 {
     public function testSerialize(): void
     {
+        /** @var string */
         $json = file_get_contents(__DIR__.'/../Fixtures/procedure.json');
 
         $serializer = new YouSignSerializer();
@@ -31,9 +33,9 @@ class ProcedureTest extends TestCase
         $this->assertSame('/procedures/9d1ede2b-5687-4440-bdc8-dd0bc64f668c', $procedure->getId());
         $this->assertSame('string', $procedure->getName());
         $this->assertSame('string', $procedure->getDescription());
-        $this->assertSame('2020-10-14T15:45:31+00:00', $procedure->getCreatedAt()->format('c'));
-        $this->assertSame('2020-10-14T15:45:31+00:00', $procedure->getUpdatedAt()->format('c'));
-        $this->assertSame('2020-10-14T15:45:31+00:00', $procedure->getExpiresAt()->format('c'));
+        $this->assertSame('2020-10-14T15:45:31+00:00', null !== $procedure->getCreatedAt() ? $procedure->getCreatedAt()->format('c') : null);
+        $this->assertSame('2020-10-14T15:45:31+00:00', null !== $procedure->getUpdatedAt() ? $procedure->getUpdatedAt()->format('c') : null);
+        $this->assertSame('2020-10-14T15:45:31+00:00', null !== $procedure->getExpiresAt() ? $procedure->getExpiresAt()->format('c') : null);
         $this->assertSame('draft', $procedure->getStatus());
         $this->assertSame('/users/9d1ede2b-5687-4440-bdc8-dd0bc64f668c', $procedure->getCreator());
         $this->assertSame('string', $procedure->getCreatorFirstName());
@@ -45,15 +47,21 @@ class ProcedureTest extends TestCase
         $this->assertTrue($procedure->isRelatedFilesEnable());
         $this->assertFalse($procedure->isArchive());
 
-        /** @var Email $emailConfig */
-        $emailConfig = $procedure->getConfig()->getEmail()->getProcedureStartedEmails()[0];
+        /** @var ProcedureConfig */
+        $procedureConfig = $procedure->getConfig();
+        /** @var ProcedureConfigEmail */
+        $procedureConfigEmail = $procedureConfig->getEmail();
+        /** @var Email */
+        $emailConfig = $procedureConfigEmail->getProcedureStartedEmails()[0];
         $this->assertSame('string', $emailConfig->getMessage());
         $this->assertSame('string', $emailConfig->getFromName());
         $this->assertSame('string', $emailConfig->getSubject());
         $this->assertSame(['@members'], $emailConfig->getTo());
 
-        /** @var Webhook $webhookConfig */
-        $webhookConfig = $procedure->getConfig()->getWebhook()->getProcedureStartedWebhooks()[0];
+        /** @var ProcedureConfigWebhook */
+        $procedureConfigWebhook = $procedureConfig->getWebhook();
+        /** @var Webhook */
+        $webhookConfig = $procedureConfigWebhook->getProcedureStartedWebhooks()[0];
         $this->assertSame('string', $webhookConfig->getUrl());
         $this->assertSame('GET', $webhookConfig->getMethod());
         $this->assertSame(['X-Yousign-Custom-Header' => 'Test value'], $webhookConfig->getHeaders());

--- a/tests/Resource/FileTest.php
+++ b/tests/Resource/FileTest.php
@@ -15,13 +15,15 @@ use Easyblue\YouSign\Http\Client;
 use Easyblue\YouSign\Model\File;
 use Easyblue\YouSign\Resources\FileResource;
 use Easyblue\YouSign\Serializer\YouSignSerializer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
 
 class FileTest extends TestCase
 {
-    private $serializer;
-    private $client;
+    private YouSignSerializer $serializer;
+    /** @var MockObject|Client */
+    private MockObject $client;
 
     protected function setUp(): void
     {
@@ -29,8 +31,9 @@ class FileTest extends TestCase
         $this->serializer = new YouSignSerializer();
     }
 
-    public function testAll()
+    public function testAll(): void
     {
+        /** @var MockObject|MessageInterface $response */
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
            ->willReturn(file_get_contents(__DIR__.'/../Fixtures/files.json'));
@@ -44,8 +47,9 @@ class FileTest extends TestCase
         $this->assertSame('string', $files[0]->getName());
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
+        /** @var MockObject|MessageInterface $response */
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
             ->willReturn(file_get_contents(__DIR__.'/../Fixtures/file.json'));
@@ -58,8 +62,9 @@ class FileTest extends TestCase
         $this->assertSame('string', $file->getName());
     }
 
-    public function testGet()
+    public function testGet(): void
     {
+        /** @var MockObject|MessageInterface $response */
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
             ->willReturn(file_get_contents(__DIR__.'/../Fixtures/file.json'));
@@ -72,8 +77,9 @@ class FileTest extends TestCase
         $this->assertSame('/files/9d1ede2b-5687-4440-bdc8-dd0bc64f668c', $file->getId());
     }
 
-    public function testDownloadAsBinary()
+    public function testDownloadAsBinary(): void
     {
+        /** @var MockObject|MessageInterface $response */
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
             ->willReturn('content');
@@ -86,8 +92,9 @@ class FileTest extends TestCase
         $this->assertSame('content', $content);
     }
 
-    public function testDownloadAsBase64()
+    public function testDownloadAsBase64(): void
     {
+        /** @var MockObject|MessageInterface $response */
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
                  ->willReturn('content');

--- a/tests/Resource/ProcedureTest.php
+++ b/tests/Resource/ProcedureTest.php
@@ -16,13 +16,15 @@ use Easyblue\YouSign\Model\File;
 use Easyblue\YouSign\Model\Procedure;
 use Easyblue\YouSign\Resources\ProcedureResource;
 use Easyblue\YouSign\Serializer\YouSignSerializer;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
 
 class ProcedureTest extends TestCase
 {
-    private $serializer;
-    private $client;
+    private YouSignSerializer $serializer;
+    /** @var MockObject|Client */
+    private MockObject $client;
 
     protected function setUp(): void
     {
@@ -30,7 +32,7 @@ class ProcedureTest extends TestCase
         $this->serializer = new YouSignSerializer();
     }
 
-    public function testAll()
+    public function testAll(): void
     {
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
@@ -45,7 +47,7 @@ class ProcedureTest extends TestCase
         $this->assertSame('string', $files[0]->getName());
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')
@@ -59,7 +61,7 @@ class ProcedureTest extends TestCase
         $this->assertSame('string', $procedure->getName());
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $response = $this->createMock(MessageInterface::class);
         $response->method('getBody')


### PR DESCRIPTION
Fixes #9 

- Rename class `Easyblue\YouSign\Model\ModeSmsConfiguration` to `OperationModeSmsConfiguration`
- Rename field `Easyblue\YouSign\Model\Member::modeSmsConfiguration` to `operationModeSmsConfiguration`
- Update test fixtures